### PR TITLE
Fix union type import

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -7,6 +7,7 @@ import {
 } from "../contract/index";
 import { HttpRequest } from "../server/index";
 import { IncomingHeaders } from "../standard/request.header";
+import { UnionToIntersection } from "../types";
 
 export type Middleware<
   Input extends MiddlewareContext<
@@ -38,12 +39,6 @@ export type MiddlewareContext<
 // Intersects all middleware outputs into a single `data` type
 export type MergeMiddlewareOutput<M extends Array<Middleware<any, any>>> =
   M extends Array<Middleware<any, infer R>> ? UnionToIntersection<R> : {};
-
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I
-) => void
-  ? I
-  : never;
 
 export type InferMiddleware<T> = T extends (
   options: infer Opt


### PR DESCRIPTION
## Summary
- reuse `UnionToIntersection` from `src/types`
- remove duplicate declaration in middleware

## Testing
- `npm run build` *(fails: Cannot find module 'zod' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684b24a283208330ade037f02a06d681