### PR TITLE
Introduce onError hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ app
 
 .use((req, res) => console.log('Hello World!'))
 
-.catch((e, req, res) => res.status(e.status ?? 500).json({ message: e.message ?? 'Internal server error' }))
+.onError((e, req, res) =>
+  res.status(e.status ?? 500).json({ message: e.message ?? 'Internal server error' })
+)
 
 .notFound((req, res) => res.status(404).end())
 


### PR DESCRIPTION
## Summary
- declare a `catchFunction` field in `Server`
- expose public `onError` method for registering a handler
- update docs to use `.onError`

## Testing
- `npm run build` *(fails: Cannot find module 'zod' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684b247eef4883309c96583a1ae95cc8