### PR TITLE
Remove unused type alias

### DIFF
--- a/src/standard/request.header.ts
+++ b/src/standard/request.header.ts
@@ -15,9 +15,6 @@ export type IncomingHeaders = {
     : K]: IncomingHttpHeaders[K];
 };
 
-
-type c = keyof IncomingHeaders;
-
 export type OutgoingHeaders = {
   [K in keyof OutgoingHttpHeaders as string extends K
     ? never


### PR DESCRIPTION
## Summary
- clean up unused `type c` alias in request headers

## Testing
- `npm run build` *(fails: Cannot find name 'Buffer')*

------
https://chatgpt.com/codex/tasks/task_e_684b24636b7c83308c7047bdcac201ae